### PR TITLE
[FEATURE] Enable redirects to other sites

### DIFF
--- a/Classes/Middleware/AuthMiddleware.php
+++ b/Classes/Middleware/AuthMiddleware.php
@@ -22,7 +22,8 @@ class AuthMiddleware implements MiddlewareInterface
     public function __construct(
         private readonly AuthService $authService,
         private readonly EventDispatcherInterface $eventDispatcher,
-        private readonly LoggerInterface $logger
+        private readonly LoggerInterface $logger,
+        private readonly SiteFinder $siteFinder
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -58,16 +59,23 @@ class AuthMiddleware implements MiddlewareInterface
             ->withPath($requestUri->getPath())
             ->withQuery($requestUri->getQuery());
 
+        try {
+            $site = $this->siteFinder->getSiteByPageId($authService->getLoginPageId());
+            $language = $site->getDefaultLanguage();
+        } catch (SiteNotFoundException) {
+            /** @var Site $site */
+            $site = $request->getAttribute('site');
+            $language = $request->getAttribute('language');
+        }
+        
         $queryParams = [
-            '_language' => $request->getAttribute('language'),
+            '_language' => $language,
             'tx_pagepassword_form' => [
                 'uid' => $request->getAttribute('routing')->getPageId(),
                 'redirect_uri' => $redirectUri->__toString(),
             ],
         ];
 
-        /** @var Site $site */
-        $site = $request->getAttribute('site');
         $uri = $site->getRouter()
             ->generateUri($authService->getLoginPageId(), $queryParams, '', RouterInterface::ABSOLUTE_PATH);
 

--- a/Classes/Middleware/AuthMiddleware.php
+++ b/Classes/Middleware/AuthMiddleware.php
@@ -12,9 +12,11 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use Rovitch\PagePassword\Event\BeforeAccessIsGrantedEvent;
 use Rovitch\PagePassword\Service\AuthService;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Routing\RouterInterface;
+use TYPO3\CMS\Core\Site\SiteFinder;
 use TYPO3\CMS\Core\Site\Entity\Site;
 
 class AuthMiddleware implements MiddlewareInterface


### PR DESCRIPTION
This change allows for generating links to other pagetrees with own sites, to have one centralized login page instead of one login page in every site of an installation.

First it detects the site of the configured login page. After that it gets the default language of that site. Both are then used to generate an link to that page, be it in the same or a different page tree than the protected page.